### PR TITLE
[Feat] 방 최소 수용인원 4인으로 변경

### DIFF
--- a/src/main/java/com/firefighter/aenitto/rooms/domain/Room.java
+++ b/src/main/java/com/firefighter/aenitto/rooms/domain/Room.java
@@ -78,7 +78,7 @@ public class Room extends CreationModificationLog {
     }
 
     public boolean cannotStart() {
-        return (5 > participantsCount());
+        return (4 > participantsCount());
     }
     public boolean unAcceptable() {
         return (capacity <= memberRooms.size());

--- a/src/main/java/com/firefighter/aenitto/rooms/dto/request/CreateRoomRequest.java
+++ b/src/main/java/com/firefighter/aenitto/rooms/dto/request/CreateRoomRequest.java
@@ -54,7 +54,7 @@ public class CreateRoomRequest {
         @Size(min = 1, max = 8)
         private final String title;
         @NotNull
-        @Min(5) @Max(15)
+        @Min(4) @Max(15)
         private final int capacity;
         @NotNull
         @CustomDate(groups = SubOrderedConstraints.class)

--- a/src/test/java/com/firefighter/aenitto/rooms/service/RoomServiceTest.java
+++ b/src/test/java/com/firefighter/aenitto/rooms/service/RoomServiceTest.java
@@ -590,7 +590,6 @@ public class RoomServiceTest {
         memberRoom2 = RoomFixture.memberRoomFixture2(member2, room1);
         memberRoom3 = RoomFixture.memberRoomFixture3(member3, room1);
         memberRoom4 = RoomFixture.memberRoomFixture4(member4, room1);
-        memberRoom5 = RoomFixture.memberRoomFixture5(member5, room1);
         ReflectionTestUtils.setField(memberRoom1, "admin", true);
         room1.setState(RoomState.PRE);
         final Relation relation = relationFixture(member1, member2, room1);
@@ -605,15 +604,14 @@ public class RoomServiceTest {
         RoomDetailResponse.RelationInfo result = target.startAenitto(member1, roomId);
 
         // then
-        assertThat(room1.getRelations().size()).isEqualTo(5);
+        assertThat(room1.getRelations().size()).isEqualTo(4);
         assertThat(room1.getRelations().get(0).getManittee()).isNotNull();
         assertThat(room1.getRelations().get(1).getManittee()).isNotNull();
         assertThat(room1.getRelations().get(2).getManittee()).isNotNull();
         assertThat(room1.getRelations().get(3).getManittee()).isNotNull();
-        assertThat(room1.getRelations().get(4).getManittee()).isNotNull();
         assertThat(result.getNickname()).isNotNull();
 
-        verify(missionService, times(5)).setInitialIndividualMission(any(MemberRoom.class));
+        verify(missionService, times(4)).setInitialIndividualMission(any(MemberRoom.class));
     }
 
 


### PR DESCRIPTION
## Issue 
- #144 

## 변경 의도
(As Is)
- 방 최소 수용인원 5인
- 5인 이상일 경우 시작 가능

(To Be)
- 방 최소 수용인원 4인
- 4인 이상일 경우 시작 가능

<br /> 

## 변경 사항
#### Prod 코드

- Room의 .cannotStart() 메서드의 조건 상수를 5 -> 4로 변경
- CreateRoomRequest Dto 클래스의 @min validation의 값을 5 -> 4로 변경

#### Test 코드 
- RoomIntegrationTest.startAenitto_4_success (새로 추가)
- RoomIntegrationTest.create_room_4_success (새로 추가)
- RoomServiceTest.startAenitto_success
  - 5인 -> 4인 조건으로 변경

